### PR TITLE
remove base url

### DIFF
--- a/.github/workflows/jekyll-gh-pages-dev.yml
+++ b/.github/workflows/jekyll-gh-pages-dev.yml
@@ -5,10 +5,6 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["dev"]
-  env:
-  # `BASE_URL` determines the website is served from, including CSS & JS assets
-  # You may need to change this to `BASE_URL: ''`
-  BASE_URL: /${{ github.event.repository.name }}
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
The base url config wasn't recognized in deployment. Just removed. 